### PR TITLE
Potential fix for code scanning alert no. 20: Server-side request forgery

### DIFF
--- a/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
+++ b/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
@@ -316,9 +316,9 @@ public final class ResourceServlet extends HttpServlet {
     );
 
     private boolean isAllowedURL(URL url) throws IOException {
-        String canonicalPath = new File(url.getPath()).getCanonicalPath();
+        String fullURL = url.toString();
         for (String allowedDir : ALLOWED_DIRECTORIES) {
-            if (canonicalPath.startsWith(new File(allowedDir).getCanonicalPath())) {
+            if (fullURL.startsWith(allowedDir)) {
                 return true;
             }
         }

--- a/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
+++ b/openidm-servlet/src/main/java/org/forgerock/openidm/ui/internal/service/ResourceServlet.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -145,6 +147,12 @@ public final class ResourceServlet extends HttpServlet {
                 if (isValidFile(file, loadDir)) {
                     url = file.getCanonicalFile().toURI().toURL();
                 }
+            }
+
+            // Validate the constructed URL against the allowed list
+            if (url != null && !isAllowedURL(url)) {
+                res.sendError(HttpServletResponse.SC_FORBIDDEN, "Access to the requested resource is forbidden.");
+                return;
             }
 
             if (url == null) {
@@ -300,5 +308,20 @@ public final class ResourceServlet extends HttpServlet {
     private boolean isValidFile(File file, String loadDir) throws IOException {
         return file.getCanonicalPath().startsWith(new File(loadDir).getCanonicalPath())
                 && file.exists() && !file.isDirectory();
+    }
+
+    private static final List<String> ALLOWED_DIRECTORIES = Arrays.asList(
+            "/allowed/dir1",
+            "/allowed/dir2"
+    );
+
+    private boolean isAllowedURL(URL url) throws IOException {
+        String canonicalPath = new File(url.getPath()).getCanonicalPath();
+        for (String allowedDir : ALLOWED_DIRECTORIES) {
+            if (canonicalPath.startsWith(new File(allowedDir).getCanonicalPath())) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/jairemis/OpenIDMfork/security/code-scanning/20](https://github.com/jairemis/OpenIDMfork/security/code-scanning/20)

To fix the SSRF vulnerability, we need to ensure that the URLs constructed from user input are strictly validated against a known set of allowed paths or domains. This can be achieved by maintaining a list of authorized URLs or directories and ensuring that the constructed URL matches one of these authorized entries.

1. Introduce a list of allowed directories or URLs that the server can access.
2. Validate the constructed URL against this list before proceeding with the request.
3. If the URL is not in the allowed list, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
